### PR TITLE
Issue/13 what is MELT section + homepage tweaks

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -25,8 +25,8 @@
             <!-- <li><a href="{{ '/' | absolute_url }}">Homepage</a></li> -->
 
             <li><a href="/">Homepage</a></li>
+            <li><a href="/melt">What is MELT?</a></li>
             <li><a href="/hld">High level diagram</a></li>
-            <li><a href="/melt">MELT</a></li>
 
             <li>
               <span class="opener">Services</span>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -2,6 +2,11 @@
     color: #e991d9;
   }
 
+  a:hover {
+    border-bottom-color: #D760C0;
+    color: #D760C0 !important;
+  }
+
   a.button:not(.special):hover {
     color: #f1a4e3 !important;
     background-color: #fff7fe;

--- a/index.md
+++ b/index.md
@@ -19,9 +19,7 @@ layout: default
         is very much a work in progress for now.
       </p>
       <ul class="actions">
-        <!-- <li><a href="#homepage-melt" class="button">What is MELT?</a></li>
-        <li><a href="#homepage-services" class="button">Services</a></li> -->
-        <li><a href="https://github.com/flam-flam" class="button special">github
+        <li><a href="https://github.com/flam-flam" class="button special">github <i class="fa fa-external-link"></i>
         </a></li>
       </ul>
     </div>
@@ -84,34 +82,34 @@ layout: default
 		<h2>Services</h2>
 	</header>
 	<p>
-		The microservices in this project are small and simple
+		The microservices in this project are small and simple.
 	</p>
 	<div class="features">
 		<article>
 			<span class="icon fa-reddit-alien"></span>
 			<div class="content">
-				<h3>Reddit dispatcher</h3>
+				<h3><a href="/services/dispatcher">Reddit dispatcher</a></h3>
 				<p>Stream submissions and comments from Reddit and forward the json objects to an endpoint. Written in Python.</p>
 			</div>
 		</article>
 		<article>
 			<span class="icon fa-comment"></span>
 			<div class="content">
-				<h3>Submission service</h3>
+				<h3><a href="/services/submission">Submission service</a></h3>
 				<p>Listen for json submission objects from the dispatcher service and save them to a database. Written in C#.</p>
 			</div>
 		</article>
 		<article>
 			<span class="icon fa-comments-o"></span>
 			<div class="content">
-				<h3>Comment service</h3>
+				<h3><a href="/services/comment">Comment service</a></h3>
 				<p>Listen for json comment objects from the dispatcher service and save them to a database. Written in NodeJS.</p>
 			</div>
 		</article>
 		<article>
 			<span class="icon fa-database"></span>
 			<div class="content">
-				<h3>MongoDB</h3>
+				<h3><a href="/services/database">MongoDB</a></h3>
 				<p>A database to store the data. Submission and comment services connect to it.</p>
 			</div>
 		</article>

--- a/index.md
+++ b/index.md
@@ -19,9 +19,9 @@ layout: default
         is very much a work in progress for now.
       </p>
       <ul class="actions">
-        <li><a href="#homepage-melt" class="button">What is MELT?</a></li>
-        <li><a href="#homepage-services" class="button">Services</a></li>
-        <li><a href="https://github.com/flam-flam" class="button special">source
+        <!-- <li><a href="#homepage-melt" class="button">What is MELT?</a></li>
+        <li><a href="#homepage-services" class="button">Services</a></li> -->
+        <li><a href="https://github.com/flam-flam" class="button special">github
         </a></li>
       </ul>
     </div>
@@ -33,7 +33,7 @@ layout: default
 	<header class="major">
 		<h2>Why?</h2>
 	</header>
-	The project is supposed to serve as a fully contained easily deployable demo of microservice observability. Want to see how it works on the dashboards? Sure. Want to rip some example code out to use in your project? You got it! The possibilities are limited.
+	The project is supposed to serve as a fully contained easily deployable demo of microservice observability. Want to see how it works on the dashboards? Sure. Want to rip some example code out to use in your project? You got it! The possibilities are... fairly limited.
 </section>
 
 
@@ -44,34 +44,35 @@ layout: default
 	</header>
 	<p>
 		MELT stands for Metrics, Events, Logs, and Traces, which are the 4 pillars of Observability.
+		Some might tell you there are 3, but that is false, fight me. <a href="/melt">Read more</a>
 	</p>
 	<div class="features">
 		<article>
 			<span class="icon fa-line-chart"></span>
 			<div class="content">
 				<h3>Metrics</h3>
-				<p>Aenean ornare velit lacus, ac varius enim lorem ullamcorper dolore. Proin aliquam facilisis ante interdum. Sed nulla amet lorem feugiat tempus aliquam.</p>
+				<p>Time series of numeric aspect of a system or an application.</p>
 			</div>
 		</article>
 		<article>
 			<span class="icon fa-list"></span>
 			<div class="content">
 				<h3>Events</h3>
-				<p>Aenean ornare velit lacus, ac varius enim lorem ullamcorper dolore. Proin aliquam facilisis ante interdum. Sed nulla amet lorem feugiat tempus aliquam.</p>
+				<p>Discreet pieces of structured data that are emitted when something interesting happens.</p>
 			</div>
 		</article>
 		<article>
 			<span class="icon fa-file-text-o"></span>
 			<div class="content">
 				<h3>Logs</h3>
-				<p>Aenean ornare velit lacus, ac varius enim lorem ullamcorper dolore. Proin aliquam facilisis ante interdum. Sed nulla amet lorem feugiat tempus aliquam.</p>
+				<p>Pieces of readable text data that are normally used by software engineers.</p>
 			</div>
 		</article>
 		<article>
 			<span class="icon fa-link"></span>
 			<div class="content">
 				<h3>Traces</h3>
-				<p>Aenean ornare velit lacus, ac varius enim lorem ullamcorper dolore. Proin aliquam facilisis ante interdum. Sed nulla amet lorem feugiat tempus aliquam.</p>
+				<p>A hierarchical set of data that contains information about a path of a request as it follows a complex path through the whole system</p>
 			</div>
 		</article>
 	</div>

--- a/pages/melt.md
+++ b/pages/melt.md
@@ -4,4 +4,98 @@ title: What is MELT?
 permalink: /melt
 ---
 
-Baby don't hurt me
+There are 4 main types of observability data - metrics, events, logs, and traces,
+often referred to as MELT data.
+They differ in format, handling, and the kind of message they're meant to convey.
+Below is a brief breakdown of what they are and their user cases.
+
+[Opentelemetry agent](https://opentelemetry.io/) we're using in this project
+can collect all 4 types.
+
+## Metrics
+
+Metric is a number that is measuring the state of some aspect of the system (software _or_ hardware).
+It is designed to be shown on a graph as a time series to show how the system is changing over time.
+The most obvious use cases are CPU/memory usage, number of HTTP 500 responses the server gave etc.
+
+Metrics are very useful when you need to output numerical data fairly often.
+They consist of two main non-numeric pieces of data: name and a list of labels.
+For instance, `cpu_usage` would be a name of the metric that contains a numeric
+measure of CPU usage - be it percentage or millicpu or whatnot.
+The labels can contain other information about the context this particular
+number was produced in, like `host=my.server.net` or `os=linux`.
+These can be set to anything you need to make it easy to understand what
+this metric actually means.
+
+In an web server case you could have a metric called `status_code_count`
+that contains counts of particular status codes
+with relevant labels like `host=my.server.net`, `app=nginx`, `status_code=(200|400|500)`.
+If the value of the metric with `status_code=500` label skyrockets, you can have
+a look at the other labels that accompany it and see which app and which server are misbehaving.
+
+The combination of labels are called "dimensions" of a metric.
+Each dimension is effectively its own time series,
+and each metric has the number of dimensions equal to product of all the label combinations.
+As an example, a metrics that has the `host` label with 3 possible values has 3 dimensions.
+If you add an `app` label with two possible values and all apps run on all hosts,
+then the number of the dimensions goes up to 3x2=6 dimensions.
+
+Observability providers like Splunk or Grafana do have limits on the dimensionality
+as each metric time series is stored separately in the backend.
+This is a good reason to not store unique values (e.g. guids) in metric dimensions,
+as the cost of storing it will balloon very quickly.
+
+## Events
+
+Events are... well, events that occur in the system, notable enough to not be a simple logline.
+This is probably the most esoteric observability data type.
+They are discreet pieces of structured data (usually JSON) that are emitted when something 
+interesting happens.
+What is considered interesting is defined by the producers and consumers of this data -
+all kind of engineers, from software to business intelligence.
+
+It is different from logs in that it's not normally informing of a point in
+a code path that has been reached (e.g. `processing the GET / request`),
+but rather a part of business logic that was triggered
+(e.g. `User clicked checkout`).
+However, events can be stored in the same place as log data, as long as they're
+clearly identifiable as events and handled accordingly.
+They can also be stored in a message bus that many teams can subscribe to and
+process them as they please.
+
+In addition, as the data is normally stored as json, it can contain the same
+labels/dimensions as all other data for easy correlation between them all.
+
+## Logs
+
+Logs are pieces of readable text data that are normally used by software engineers.
+The contents are arbitrary and a use case depends on what you're doing, but
+the generally the logs should inform of the state of the code rather than business events.
+
+There is no standard format - it can be plain text, key value pairs, json - by it
+is generally a good idea to keep logs within a single line as
+most log aggregators struggle to parse multiline logs (like Loki)
+or just use much more resources to do so (like Splunk).
+
+While there isn't a standard, it is generally a good idea to make the logging
+as structured as possible as it make extracting any useful data programmatically
+much easier.
+This is, of course, not
+
+## Traces
+
+Traces are a hierarchical set of data that contains information about a path of
+a request as it follows a complex code/network path through the whole system, start to finish.
+They're most useful in a microservice environment (distributed traces) where a request
+can hop from service to service and measure data on the way about how it performed,
+but it can equally be applied to a monolith and measure the performance of each function
+it went through.
+This type of observability is focused on the software rather than the hardware.
+
+Each trace consists of a set of nested spans that measure how a particular
+microservice (or function) performed in that particular instance.
+Spans can contain numeric data like `duration` of the time it spent
+at a particular stage, like a call to an Auth service, or an underlying database request.
+They can also contain a context of the requrest, like which parameters were passed.
+This way we get a view across the whole stack of services, and if any of them
+stop performing well, we will instantly see which one it is.


### PR DESCRIPTION
Mainly populated the What is MELT? section. Please have a look at it as it might be misguided :)


In addition:
- Removed the buttons on the homepage to naviage _within_ the homepage - seems redundant
- Added "Read more" link under the What is MELT? section of the homepage
- Added links from the homepage to the indifidual services

Closes #13 